### PR TITLE
Move the init code to native and remove it from javascript

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,7 @@
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="ClientStats">
         <param name="android-package" value="edu.berkeley.eecs.emission.cordova.clientstats.ClientStatsPlugin"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 
@@ -39,6 +40,7 @@
     <config-file target="config.xml" parent="/*">
       <feature name="ClientStats">
         <param name="ios-package" value="BEMClientStatsPlugin" />
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 

--- a/src/android/ClientStatsPlugin.java
+++ b/src/android/ClientStatsPlugin.java
@@ -9,6 +9,14 @@ import android.content.Context;
 import edu.berkeley.eecs.emission.cordova.clientstats.ClientStatsHelper;
 
 public class ClientStatsPlugin extends CordovaPlugin {
+
+    protected void pluginInitialize() {
+        new ClientStatsHelper(cordova.getActivity()).storeMeasurement(
+                "app_launched", // key
+                null, // value
+                String.valueOf(System.currentTimeMillis()));
+    }
+
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
         if (action.equals("storeMeasurement")) {
@@ -21,7 +29,7 @@ public class ClientStatsPlugin extends CordovaPlugin {
             return true;
         } else if (action.equals("storeEventNow")) {
             Context ctxt = cordova.getActivity();
-            (new ClientStatsHelper(ctxt)).storeMeasurement(
+            new ClientStatsHelper(ctxt).storeMeasurement(
                 data.getString(0), // key
                 null, // value
                 String.valueOf(System.currentTimeMillis())); // ts

--- a/src/ios/BEMClientStatsPlugin.m
+++ b/src/ios/BEMClientStatsPlugin.m
@@ -3,6 +3,15 @@
 
 @implementation BEMClientStatsPlugin
 
+- (void)pluginInitialize
+{
+    // TODO: We should consider adding a create statement to the init, similar
+    // to android - then it doesn't matter if the pre-populated database is not
+    // copied over.
+    NSLog(@"BEMClientStatsPlugin pluginInitialize singleton -> initialize native DB");
+    [[ClientStatsDatabase database] storeEventNow:@"app_launched"];
+}
+
 - (void)storeMeasurement:(CDVInvokedUrlCommand*)command
 {
     NSString* callbackId = [command callbackId];

--- a/www/clientstats.js
+++ b/www/clientstats.js
@@ -20,9 +20,6 @@ var ClientStats = {
      * instead of copying the template.
      */
     init: function() {
-        ClientStats.storeEventNow("app_launched", function(error) {
-            alert("Error "+error+" while initializing the client stats database");
-        });
         ClientStats.db = window.sqlitePlugin.openDatabase({
             name: "clientStatsDB",
             location: 0,


### PR DESCRIPTION
Also make the plugin load on start
The db variable is still initialized on init, but we can change it to be
initialized on demand instead since we are unlikely to make many transactions
in quick succession.
